### PR TITLE
fix: python version range for typing_extensions dep

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ license-expression = 'LGPL-3.0-or-later'
 dependencies = [
     'tomli>=2.0; python_version < "3.11"',
     'packaging>=21.3',
-    'typing-extensions; python_version < "3.10"',
+    'typing-extensions; python_version < "3.8"',
 ]
 requires-python = '>=3.7, <=3.11'
 


### PR DESCRIPTION
The typing_extensions package is only used in Python < 3.8, so adjust
the dependency accordingly.